### PR TITLE
バリデーションエラー時の動作追加

### DIFF
--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -50,7 +50,7 @@ public class StudentController {
   @PostMapping("/registerStudent")
   public String registerStudent(@ModelAttribute StudentDetail studentDetail, BindingResult result){
     if(result.hasErrors()){
-      return "registerStudent";
+      return "typeError";
     }
     //新規受講生情報を登録する
     service.registerStudentDetail(studentDetail);

--- a/src/main/resources/templates/RegisterStudent.html
+++ b/src/main/resources/templates/RegisterStudent.html
@@ -1,47 +1,56 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymleaf.org", lang="jp">
 <head>
-  <title>受講生一覧</title>
+  <title>受講生登録</title>
 </head>
 <body>
-<h1>受講生一覧<h1>
+<h1>受講生登録</h1>
 <form th:action="@{/registerStudent}" th:object="${studentDetail}" method="post">
   <div>
     <label for="name">ID:</label>
-    <input type="text" id="id" th:field="*{student.studentId}" required>
+    <input type="text" id="studentId" th:field="*{student.studentId}" required>
   </div>
+  <p></p>
   <div>
     <label for="name">名前:</label>
     <input type="text" id="name" th:field="*{student.name}" required>
   </div>
+  <p></p>
   <div>
     <label for="name">ふりがな:</label>
     <input type="text" id="nameReading" th:field="*{student.nameReading}" required>
   </div>
+  <p></p>
   <div>
     <label for="name">ニックネーム:</label>
     <input type="text" id="nickname" th:field="*{student.nickname}" required>
   </div>
+  <p></p>
   <div>
     <label for="name">メールアドレス:</label>
     <input type="text" id="mailAddress" th:field="*{student.mailAddress}" required>
   </div>
+  <p></p>
   <div>
     <label for="name">居住地:</label>
     <input type="text" id="city" th:field="*{student.city}" required>
   </div>
+  <p></p>
   <div>
     <label for="name">年齢:</label>
     <input type="text" id="age" th:field="*{student.age}" required>
   </div>
+  <p>※年齢は数字のみ記入</p>
   <div>
     <label for="name">性別:</label>
     <input type="text" id="gender" th:field="*{student.gender}" required>
   </div>
+  <p></p>
   <div>
     <label for="name">備考:</label>
     <input type="text" id="remark" th:field="*{student.remark}" required>
   </div>
+  <p></p>
   <div>
     <button type="submit">登録</button>
   </div>

--- a/src/main/resources/templates/TypeError.html
+++ b/src/main/resources/templates/TypeError.html
@@ -6,6 +6,6 @@
 <body>
 <h1>入力エラー</h1>
   <p>正しく入力してください。</p>
-  <button onclick="history.back()">登録画面に戻る</button>
+  <button onclick="location.href='/newStudent'">登録画面に戻る</button>
 </body>
 </html>

--- a/src/main/resources/templates/TypeError.html
+++ b/src/main/resources/templates/TypeError.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="jp">
+<head>
+  <title>入力エラー</title>
+</head>
+<body>
+<h1>入力エラー</h1>
+  <p>正しく入力してください。</p>
+  <button onclick="history.back()">登録画面に戻る</button>
+</body>
+</html>


### PR DESCRIPTION
# バリデーションエラーが発生した時に入力エラーを知らせるページに遷移するようにしました

* 入力エラーを知らせるページを表示するHTMLファイルTypeErrorを作成しました
　　* 「登録画面に戻る」ボタンを押下すると受講生登録画面に戻ります（直前のページに戻るようにしています）
* コントローラーでバリデーションエラーが発生した際にTypeErrorページに遷移するようにコードを更新しました
* 生徒情報登録画面の表示を変更しました
　　* 生徒情報一覧 → 生徒情報登録
　　* 項目名を細字の表示にしました
　　* 項目同士の間に空白行を追加しました
　　* 「※年齢は数字のみ記入」の文を追加しました

以下の画像は登録画面とバリデーションエラー時の画面です
![image](https://github.com/user-attachments/assets/40730ee1-3c82-415b-a1e4-c79ceffab21d)
![image](https://github.com/user-attachments/assets/0751f081-5da9-410c-9c45-037fd1ab7329)